### PR TITLE
Ajout test avant requete et suppression vue de trop

### DIFF
--- a/mvc/Controleur/controleur.php
+++ b/mvc/Controleur/controleur.php
@@ -21,22 +21,30 @@ function ctrlVerifierId($usr,$mdp){
     }
 }
 
-function ctrlGestionMotif(){
-    vueGestionMotif();
-}
-
 function ctrlGetAllMotif(){
     $motif = mdlGetAllMotif();
     vueGetAllMotif($motif);
 }
 
 function ctrlModifierPiece($motif){
-    $id = $motif["modifier"];
-    $value = $motif["valeurModifier"];
+    if(isset($motif["modifier"]) && isset($motif["valeurModifier"])){
 
-    mdlModifierPiece($id, $value);
+        if(strlen($motif["valeurModifier"]) > 0){
 
-    vueMsgDirecteur("Le motif a bien été modifié");
+            $id = $motif["modifier"];
+            $value = $motif["valeurModifier"];
+        
+            mdlModifierPiece($id, $value);
+        
+            vueMsgDirecteur("Le motif a bien été modifié");
+
+        } else {
+            vueMsgDirecteur("Veuillez remplir le nouveau motif");
+        }
+
+    } else {
+        vueMsgDirecteur("Veuillez selectionner un motif");
+    }
 }
 
 function ctrlErreur($erreur){
@@ -58,7 +66,7 @@ function ctrlSupprimerTypeAccount($type){
 
             if($result == false){
 
-                $name = mdlGetType($type["account"], "account")->nom;
+                $name = mdlGetTypeById($type["account"], "account")->nom;
                 mdlSupprimerMotif($name);
                 mdlSupprimerType($type["account"], "account");
                 vueMsgDirecteur('Le type de compte "'.$name.'" a bien été supprimé');
@@ -79,7 +87,7 @@ function ctrlSupprimerTypeAccount($type){
 
             if($result == false){
 
-                $name = mdlGetType($type["contract"], "contract")->nom;
+                $name = mdlGetTypeById($type["contract"], "contract")->nom;
                 mdlSupprimerMotif($name);
                 mdlSupprimerType($type["contract"], "contract");
                 vueMsgDirecteur('Le type de contrat "'.$name.'" a bien été supprimé');
@@ -96,14 +104,25 @@ function ctrlSupprimerTypeAccount($type){
 }
 
 function ctrlAjouterType($newType){
-    //TODO empecher création compte avec même nom
-    $nature = $newType["nature"];
-    $nom = $newType["nom"];
-    $pieceCreation = $newType["pieceCreation"];
-    $pieceModification = $newType["pieceModification"];
-    $pieceSuppression = $newType["pieceSuppression"];
 
-    mdlAjouterType($nature, $nom, $pieceCreation, $pieceModification, $pieceSuppression);
-
-    vueMsgDirecteur("Youpi nouveau type créé");
+    if(strlen($newType["nom"]) > 0 && strlen($newType["nature"]) > 0 && strlen($newType["pieceCreation"]) > 0 &&
+        strlen($newType["pieceModification"]) > 0 && strlen($newType["pieceSuppression"]) > 0){
+            
+        $nom = $newType["nom"];
+        $nature = $newType["nature"];
+        $pieceCreation = $newType["pieceCreation"];
+        $pieceModification = $newType["pieceModification"];
+        $pieceSuppression = $newType["pieceSuppression"];
+        
+        if(mdlGetTypeByName($nom, "account") == false && mdlGetTypeByName($nom, "contract") == false){
+            
+            mdlAjouterType($nature, $nom, $pieceCreation, $pieceModification, $pieceSuppression);
+            
+            vueMsgDirecteur('Le '.$nature.'"'.$nom.'" a bien été créer');
+        } else {
+            vueMsgDirecteur('Le nom "'.$nom.'" est déjà utilisé pour un type de compte ou contrat');
+        }
+    } else {
+        vueMsgDirecteur("Tous les champs de texte n'ont pas été remplis");
+    }
 }

--- a/mvc/Modele/modele.php
+++ b/mvc/Modele/modele.php
@@ -76,6 +76,27 @@ function mdlGetAllTypeContract(){
     return $typeContract;
 }
 
+function mdlGetTypeByName($name, $type){
+
+    $connexion = getConnexion();
+
+    $requete = '';
+    if($type == 'account'){
+        $requete = 'SELECT * FROM typecompte WHERE nom = "'.$name.'";';
+    }elseif($type == 'contract'){
+        $requete = 'SELECT * FROM typecontrat WHERE nom = "'.$name.'";';
+    }else{
+        throw new Exception("Type non définie pour la requête GetTypeByName");
+    }
+
+    $resultat = $connexion->query($requete);
+    $resultat->setFetchMode(PDO::FETCH_OBJ);
+    $queryResult = $resultat->fetch();
+    $resultat->closeCursor();
+
+    return $queryResult;
+}
+
 function mdlAjouterType($nature, $nom, $pieceCreation, $pieceModification, $pieceSuppression){
     $connexion = getConnexion();
 
@@ -129,7 +150,7 @@ function mdlSupprimerType($id, $type){
     $resultat->closeCursor();
 }
 
-function mdlGetType($id, $type){
+function mdlGetTypeById($id, $type){
 
     $connexion = getConnexion();
 
@@ -139,15 +160,15 @@ function mdlGetType($id, $type){
     }elseif($type == 'contract'){
         $requete = 'SELECT * FROM typecontrat WHERE id = '.$id.';';
     }else{
-        throw new Exception("Type non définie pour la requête GetType");
+        throw new Exception("Type non définie pour la requête GetTypeById");
     }
 
     $resultat = $connexion->query($requete);
     $resultat->setFetchMode(PDO::FETCH_OBJ);
-    $type = $resultat->fetch();
+    $queryResult = $resultat->fetch();
     $resultat->closeCursor();
 
-    return $type;
+    return $queryResult;
 }
 
 function mdlSupprimerMotif($name){

--- a/mvc/Vue/gabaritDirecteur.php
+++ b/mvc/Vue/gabaritDirecteur.php
@@ -13,7 +13,7 @@
 			  		<li>
               <form method='post' action="sprintBank.php">
                 <p>
-                  <input type="submit" name="gestionMotif" value="Gestion des motifs">
+                  <input type="submit" name="showAllMotif" value="Gestion des motifs">
                 </p>
               </form>
             </li>
@@ -27,7 +27,8 @@
 		  			<li>Statistiques</li>
 		  		</ul>
 			</nav>
-      <?php echo $contenu; ?>
+      <?php if(isset($contenu)){
+        echo $contenu;} ?>
     </body>
 </html>
 

--- a/mvc/Vue/vue.php
+++ b/mvc/Vue/vue.php
@@ -19,30 +19,6 @@ function pageConseille(){
     require_once('Vue/gabaritConseille.php');
 }
 
-
-function erreurId(){
-        $contenu ='<p>Identifiants faux</p>';
-        require_once('Vue/gabaritLogin.php');
-    }
-    
-function vueGestionMotif(){
-
-    $contenu = '<ul>
-                    <li>
-                        <form method="post" action="sprintBank.php">
-                            <p>
-                                <input type="submit" name="showAllMotif" value="Afficher tous motifs">
-                            </p>
-                        </form>
-                    </li>
-                    <li>
-                        <p>A remplir</p>
-                    </li>
-                </ul>';
-    require_once('Vue/gabaritDirecteur.php');
-
-}
-
 function vueGetAllMotif($motif){
     $contenu = '<fieldset><legend>Liste des motifs</legend><form method="post" action="sprintBank.php">';
     if(sizeof($motif) > 0){
@@ -124,5 +100,10 @@ function vueGetAllTypeAccountContract($account, $contract){
 
 function afficherErreur($erreur){
     $contenu='<p>'. $erreur.'</p>';
+    require_once('Vue/gabaritLogin.php');
+}
+
+function erreurId(){
+    $contenu ='<p>Identifiants faux</p>';
     require_once('Vue/gabaritLogin.php');
 }

--- a/mvc/sprintBank.php
+++ b/mvc/sprintBank.php
@@ -7,16 +7,12 @@ try {
         $mdp=$_POST['mdp'];
         ctrlVerifierId($usr,$mdp);
         
-    }elseif (isset($_POST['gestionMotif'])){
-
-        ctrlGestionMotif();
-
     }elseif (isset($_POST['showAllMotif'])){
 
         ctrlGetAllMotif();
 
     }elseif (isset($_POST['modifierPiece'])){
-
+        
         ctrlModifierPiece($_POST);
 
     }elseif (isset($_POST['gestionTypeCompteContrat'])){


### PR DESCRIPTION
Ajout :
+ (+) vérification champs modif motif
+ (+) ajout getTypeByName et modif name GetType par GetTypeById
+ (+) ajout vérification nom non existant avant création compte/contrat
+ (+) ajout vérification tous champs remplient avant création compte/contrat

- (-) suppression de la vue gestion motif (button en plus avant d'avoir getAllMotif)